### PR TITLE
WrenSec Builds - Phase #1 (for wrensec-audit)

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,3 @@
+export MAVEN_PACKAGE="forgerock-audit"
+export BINTRAY_PACKAGE="wrensec-audit"
+export JFROG_PACKAGE="org/forgerock/commons/forgerock-audit"

--- a/forgerock-audit-core/pom.xml
+++ b/forgerock-audit-core/pom.xml
@@ -13,6 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyright 2017 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,7 +24,7 @@
     </parent>
     <artifactId>forgerock-audit-core</artifactId>
     <packaging>bundle</packaging>
-    <name>Commons - ForgeRock Audit Framework Core</name>
+    <name>Wren Security Commons - Audit Framework Core</name>
     <description />
 
     <dependencies>

--- a/forgerock-audit-handler-csv/pom.xml
+++ b/forgerock-audit-handler-csv/pom.xml
@@ -13,6 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyright 2017 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,7 +24,7 @@
     </parent>
     <artifactId>forgerock-audit-handler-csv</artifactId>
     <packaging>bundle</packaging>
-    <name>Commons - ForgeRock Audit CSV Event Handler</name>
+    <name>Wren Security Commons - Audit CSV Event Handler</name>
     <description />
 
     <dependencies>

--- a/forgerock-audit-handler-jdbc/pom.xml
+++ b/forgerock-audit-handler-jdbc/pom.xml
@@ -13,6 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyright 2017 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
@@ -24,7 +25,7 @@
 
     <artifactId>forgerock-audit-handler-jdbc</artifactId>
     <packaging>bundle</packaging>
-    <name>Commons - ForgeRock Audit JDBC Event Handler</name>
+    <name>Wren Security Commons - Audit JDBC Event Handler</name>
     <description>Writes audit event to a configured JDBC database</description>
 
     <properties>

--- a/forgerock-audit-handler-syslog/pom.xml
+++ b/forgerock-audit-handler-syslog/pom.xml
@@ -13,6 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyright 2017 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -24,7 +25,7 @@
 
     <artifactId>forgerock-audit-handler-syslog</artifactId>
     <packaging>bundle</packaging>
-    <name>Commons - ForgeRock Audit Syslog Event Handler</name>
+    <name>Wren Security Commons - Audit Syslog Event Handler</name>
     <description />
 
     <dependencies>

--- a/forgerock-audit-json/pom.xml
+++ b/forgerock-audit-json/pom.xml
@@ -13,6 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyright 2017 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,7 +24,7 @@
     </parent>
     <artifactId>forgerock-audit-json</artifactId>
     <packaging>bundle</packaging>
-    <name>Commons - ForgeRock Audit Json Support</name>
+    <name>Wren Security Commons - Audit Json Support</name>
     <description />
 
     <dependencies>

--- a/forgerock-audit-servlet/pom.xml
+++ b/forgerock-audit-servlet/pom.xml
@@ -13,6 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyright 2017 Wren Security.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,7 +24,7 @@
     </parent>
     <artifactId>forgerock-audit-servlet</artifactId>
     <packaging>bundle</packaging>
-    <name>Commons - ForgeRock Audit Framework Servlet</name>
+    <name>Wren Security Commons - Audit Framework Servlet</name>
     <description />
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyright 2017 Wren Security.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -25,8 +26,9 @@
     <groupId>org.forgerock.commons</groupId>
     <artifactId>forgerock-audit</artifactId>
     <version>4.1.1</version>
-    <name>Commons - ForgeRock Audit Framework</name>
-    <description>Implements the commons audit framework.</description>
+    <name>Wren Security Commons - Audit Framework</name>
+    <description>Common access auditing &amp; logging framework for Wren Security forks of ForgeRock products.</description>
+    <url>http://wrensecurity.org</url>
     <packaging>pom</packaging>
     <licenses>
         <license>
@@ -40,15 +42,14 @@
         </license>
     </licenses>
     <issueManagement>
-       <system>Jira</system>
-       <url>https://bugster.forgerock.org/jira/browse/COMMONS</url>
+        <system>GitHub Issues</system>
+        <url>https://github.com/WrenSecurity/wrensec-audit/issues</url>
     </issueManagement>
     <scm>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-audit.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-audit.git</developerConnection>
-        <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-audit/browse</url>
-      <tag>4.1.1</tag>
-  </scm>
+        <url>https://github.com/WrenSecurity/wrensec-audit</url>
+        <connection>scm:git:git://github.com/WrenSecurity/wrensec-audit.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-audit.git</developerConnection>
+    </scm>
     <properties>
         <commons.forgerock-bom.version>4.1.1</commons.forgerock-bom.version>
 
@@ -111,21 +112,44 @@
 
     <repositories>
         <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
+            <id>bintray-wrensecurity-releases</id>
+            <name>Wren Security Release Repository</name>
+            <url>http://dl.bintray.com/wrensecurity/releases</url>
+
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+
+            <releases>
+                <enabled>true</enabled>
+            </releases>
         </repository>
 
         <repository>
-            <id>forgerock-snapshots-repository</id>
-            <name>ForgeRock Snapshot Repository</name>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
+            <id>bintray-wrensecurity-snapshots</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>http://dl.bintray.com/wrensecurity/snapshots</url>
+
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+
             <releases>
                 <enabled>false</enabled>
             </releases>
         </repository>
     </repositories>
+    <distributionManagement>
+        <snapshotRepository>
+            <id>bintray-wrensecurity-releases</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-audit/;publish=1</url>
+        </snapshotRepository>
+
+        <repository>
+            <id>bintray-wrensecurity-snapshots</id>
+            <name>Wren Security Release Repository</name>
+            <url>${forgerockDistMgmtReleasesUrl}/wrensec-audit/;publish=1</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -111,10 +111,11 @@
     </dependencyManagement>
 
     <repositories>
+        <!-- Needed to retrieve parent POM -->
         <repository>
-            <id>bintray-wrensecurity-releases</id>
+            <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
-            <url>http://dl.bintray.com/wrensecurity/releases</url>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
 
             <snapshots>
                 <enabled>false</enabled>
@@ -122,34 +123,21 @@
 
             <releases>
                 <enabled>true</enabled>
-            </releases>
-        </repository>
-
-        <repository>
-            <id>bintray-wrensecurity-snapshots</id>
-            <name>Wren Security Snapshot Repository</name>
-            <url>http://dl.bintray.com/wrensecurity/snapshots</url>
-
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-
-            <releases>
-                <enabled>false</enabled>
             </releases>
         </repository>
     </repositories>
+
     <distributionManagement>
         <snapshotRepository>
-            <id>bintray-wrensecurity-releases</id>
+            <id>wrensecurity-snapshots</id>
             <name>Wren Security Snapshot Repository</name>
-            <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-audit/;publish=1</url>
+            <url>${forgerockDistMgmtSnapshotsUrl}</url>
         </snapshotRepository>
 
         <repository>
-            <id>bintray-wrensecurity-snapshots</id>
+            <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
-            <url>${forgerockDistMgmtReleasesUrl}/wrensec-audit/;publish=1</url>
+            <url>${forgerockDistMgmtReleasesUrl}</url>
         </repository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
- modifies the POMs to build using Wren's repos.
- updates branding to call this Wren Security Commons Audit instead of ForgeRock Commons Audit.
- adds [Wren Deploy](https://github.com/WrenSecurity/wrensec-deploy-tool) RC file.
- the `sustaining/*` branches have already been updated with similar changes.